### PR TITLE
Adding 'Referer' header to allow for full speed downloads

### DIFF
--- a/threads/download_threads.py
+++ b/threads/download_threads.py
@@ -399,7 +399,8 @@ class DownloadThread(QThread):
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
             'Accept': '*/*',
             'Accept-Encoding': 'gzip, deflate, br',
-            'Connection': 'keep-alive'
+            'Connection': 'keep-alive',
+            'Referer' : "https://myrient.erista.me/"
         }
 
         for i in range(self.retries):


### PR DESCRIPTION
Myrient only removes the download throttle if this is present. Download speeds went from ~15kb/s to over 100mb/s with this change.