### PR TITLE
Fix large queue issues

### DIFF
--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -85,11 +85,10 @@ class AppController(QObject):
         platform_name = current_platform.upper()
         
         for item in selected_items:
-            item_text = item.text()
-            formatted_text = f"({platform_name}) {item_text}"
+            formatted_text = f"({platform_name}) {item}"
             
             # Get file size from the stored JSON data
-            file_size = self._get_file_size_from_cache(current_platform, item_text)
+            file_size = self._get_file_size_from_cache(current_platform, item)
             
             # Create item data with size
             item_data = {
@@ -266,7 +265,7 @@ class AppController(QObject):
                     
                     # Remove the skipped item to avoid infinite loop
                     queue_list_widget.takeTopLevelItem(0)
-                    self.save_queue(queue_list_widget)
+                    self.queue_manager.pop_front_queue_item()
                     continue
                 
                 # Reset skip counter when we find a processable item
@@ -294,8 +293,7 @@ class AppController(QObject):
                 # Remove item from queue if not paused
                 if not self.is_paused:
                     queue_list_widget.takeTopLevelItem(0)
-                    # Save queue immediately after removing completed item
-                    self.save_queue(queue_list_widget)
+                    self.queue_manager.pop_front_queue_item()
                 
                 is_resuming_session = False
         except RuntimeError as e:
@@ -412,10 +410,17 @@ class AppController(QObject):
                         self._update_queue_item_status(paused_item_widget, "PAUSED", QColor(255, 215, 0), "(PAUSED)")
 
                         # Add remaining items from the original loaded queue
+                        items = []
                         for other_item_data in loaded_queue_items_from_file:
                             other_item_name = other_item_data.get('name') if isinstance(other_item_data, dict) else other_item_data
                             if other_item_name != item_name_from_storage:
-                                self.queue_manager.add_formatted_item_to_queue(other_item_data, queue_list_widget)
+                                items.append(other_item_data)
+                        self.queue_manager.add_formatted_items_to_queue(
+                            items,
+                            queue_list_widget,
+                            create_buttons=False,
+                            fetch_missing_size=False
+                        )
                         
                         # Set AppController state for this paused item
                         self.current_item = item_name_from_storage
@@ -444,8 +449,12 @@ class AppController(QObject):
         if not pause_state:
             # No physical file and no saved state, so just load the queue normally if it wasn't already
             if queue_list_widget.topLevelItemCount() == 0: # Check if queue is empty
-                 for item_data_s in loaded_queue_items_from_file:
-                    self.queue_manager.add_formatted_item_to_queue(item_data_s, queue_list_widget)
+                self.queue_manager.add_formatted_items_to_queue(
+                    loaded_queue_items_from_file,
+                    queue_list_widget,
+                    create_buttons=False,
+                    fetch_missing_size=False
+                )
             return False
             
         # Clear the current queue if we are restoring from StateManager
@@ -456,11 +465,18 @@ class AppController(QObject):
         self._update_queue_item_status(paused_item, "PAUSED", QColor(255, 215, 0), "(PAUSED)")
         
         if 'remaining_queue' in pause_state and isinstance(pause_state['remaining_queue'], list):
+            remaining_items = []
             for item_data in pause_state['remaining_queue']:
                 item_text = item_data['name'] if isinstance(item_data, dict) else item_data
                 current_text = current_item_data['name'] if isinstance(current_item_data, dict) else current_item_data
                 if item_text != current_text:
-                    self.queue_manager.add_formatted_item_to_queue(item_data, queue_list_widget)
+                    remaining_items.append(item_data)
+            self.queue_manager.add_formatted_items_to_queue(
+                remaining_items,
+                queue_list_widget,
+                create_buttons=False,
+                fetch_missing_size=False
+            )
         
         if isinstance(current_item_data, dict):
             self.current_item = current_item_data['name']

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -36,19 +36,72 @@ psp:
   tab_name: "PSP (ISO)"
   url: "https://myrient.erista.me/files/Redump/Sony%20-%20PlayStation%20Portable/"
 
+dreamcast:
+  tab_name: "Dreamcast (ISO)"
+  url: "https://myrient.erista.me/files/Redump/Sega%20-%20Dreamcast/"
+
+dreamcastgdi:
+  tab_name: "Dreamcast (GDI)"
+  url: "https://myrient.erista.me/files/Redump/Sega%20-%20Dreamcast%20-%20GDI%20Files/"
+
+ds:
+  tab_name: "DS (DS)"
+  url: "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Nintendo%20DS%20%28Decrypted%29/"
+
+gameboy:
+  tab_name: "GameBoy (GB)"
+  url: "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Game%20Boy/"
+
+gameboycolor:
+  tab_name: "GameBoy Color (GBC)"
+  url: "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Game%20Boy%20Color/"
+
+gameboyadv:
+  tab_name: "GameBoy Advance (GBA)"
+  url: "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Game%20Boy%20Advance/"
+
 gamecube:
   tab_name: "GameCube (RVZ)"
   url: "https://myrient.erista.me/files/Redump/Nintendo%20-%20GameCube%20-%20NKit%20RVZ%20[zstd-19-128k]/"
 
+n64:
+  tab_name: "N64 (Z64)"
+  url: "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Nintendo%2064%20%28BigEndian%29/"
+
+n64v:
+  tab_name: "N64 (V64)"
+  url: "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Nintendo%2064%20%28ByteSwapped%29/"
+
+snes:
+  tab_name: "SNES (SFC)"
+  url: "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Super%20Nintendo%20Entertainment%20System/"
+
 wii:
   tab_name: "Wii (RVZ)"
   url: "https://myrient.erista.me/files/Redump/Nintendo%20-%20Wii%20-%20NKit%20RVZ%20[zstd-19-128k]/"
+
+xbox:
+  tab_name: "Xbox (ISO)"
+  url: "https://myrient.erista.me/files/Redump/Microsoft%20-%20Xbox/"
+
+xbox360:
+  tab_name: "Xbox 360 (ISO)"
+  url: "https://myrient.erista.me/files/Redump/Microsoft%20-%20Xbox%20360/"
+
+xbox360tu:
+  tab_name: "Xbox 360 Title Updates (TU)"
+  url: "https://myrient.erista.me/files/No-Intro/Unofficial%20-%20Microsoft%20-%20Xbox%20360%20%28Title%20Updates%29/"
+
+xbox360digital:
+  tab_name: "Xbox 360 Digital (XBLA)"
+  url: "https://myrient.erista.me/files/No-Intro/Microsoft%20-%20Xbox%20360%20%28Digital%29/"
 """
     
     def __init__(self, config_file=None):
         self.config_file = config_file or self.DEFAULT_CONFIG_PATH
         self.config = {}
-        self.ensure_config_exists()
+        # Ensure latest config sources
+        self.generate_default_config()
         self.load_config()
     
     def load_config(self):
@@ -74,22 +127,18 @@ wii:
             sys.stderr.flush()
     
     def ensure_config_exists(self):
-        """Ensure the configuration file exists, downloading it from GitHub if needed."""
-        # Check in working directory
-        config_filename = os.path.basename(self.config_file)
-        if os.path.exists(config_filename):
-            self.config_file = config_filename
-            return
-        
+        """Ensure the configuration file exists."""
         # Check in config directory
         if os.path.exists(self.config_file):
             return
         
         # Neither location has the config, generate default
         sys.stderr.write(f"Configuration file not found at {self.config_file}\n")
+        self.generate_default_config()
+
+    def generate_default_config(self):
         sys.stderr.write("Generating default myrient_urls.yaml configuration offline.\n")
         sys.stderr.flush()
-        
         try:
             # Create config directory if it doesn't exist
             os.makedirs(os.path.dirname(self.config_file), exist_ok=True)

--- a/core/database.py
+++ b/core/database.py
@@ -61,6 +61,14 @@ class AppDatabase:
                 )
             
             conn.commit()
+
+    def pop_front_queue_item(self):
+        """Pop front queue item."""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute('DELETE FROM queue WHERE position = 0')
+            cursor.execute('UPDATE queue SET position = position - 1 WHERE position > 0')
+            conn.commit()
             
     # List Cache Operations
     def get_list_cache(self, platform_id):

--- a/core/queue_manager.py
+++ b/core/queue_manager.py
@@ -4,8 +4,8 @@ from PyQt5.QtCore import Qt, QObject, pyqtSignal, QSize
 from PyQt5.QtWidgets import QTreeWidgetItem, QListWidgetItem
 from PyQt5.QtGui import QFont, QBrush, QColor
 
+from core.database import AppDatabase
 from core.utils import format_file_size
-
 
 class QueueManager(QObject):
     """Manages download queue operations separate from GUI."""
@@ -17,10 +17,11 @@ class QueueManager(QObject):
         self.queue_items = []
         self.data_dir = os.path.join("MyrientDownloads", "data")
         self.queue_file = os.path.join(self.data_dir, "queue.txt")
+        self.queue_item_class = None
+        self.queue_item_parent = None
     
     def load_queue(self):
         """Load the download queue from database."""
-        from core.database import AppDatabase
         try:
             db = AppDatabase()
             self.queue_items = db.get_queue()
@@ -42,13 +43,25 @@ class QueueManager(QObject):
             queue_items.append(item_data)
         
         try:
-            from core.database import AppDatabase
             db = AppDatabase()
             db.save_queue(queue_items)
         except Exception as e:
             print(f"Error saving queue to database: {e}")
         
         self.queue_items = queue_items
+        self.queue_updated.emit()
+
+    def pop_front_queue_item(self):
+        """Remove the first queue item from database."""
+        try:
+            db = AppDatabase()
+            db.pop_front_queue_item()
+        except Exception as e:
+            print(f"Error popping front queue item: {e}")
+            return
+
+        if self.queue_items:
+            self.queue_items = self.queue_items[1:]
         self.queue_updated.emit()
     
     def add_to_queue(self, item_data, queue_list_widget, platforms):
@@ -73,26 +86,37 @@ class QueueManager(QObject):
             return True
         return False
     
-    def add_formatted_item_to_queue(self, queue_data, queue_tree_widget):
-        """Add an item to the queue list with file size column."""
-        # Try to import QueueTreeWidgetItem, fallback to standard QTreeWidgetItem
+    def _get_queue_tree_parent(self, queue_tree_widget):
+        """Get and cache QueueTreeWidgetItem parent."""
+        if self.queue_item_class is not None:
+            return
+
         try:
             from gui.main_window import QueueTreeWidgetItem
-            # Get the main window instance from the queue tree widget
-            main_window = None
-            parent = queue_tree_widget.parent()
-            while parent:
-                if hasattr(parent, 'move_queue_item_up_inline'):
-                    main_window = parent
-                    break
-                parent = parent.parent()
-            
-            if main_window:
-                tree_item = QueueTreeWidgetItem(['', '', ''], main_window)
-            else:
-                tree_item = QTreeWidgetItem()
+            self.queue_item_class = QueueTreeWidgetItem
         except ImportError:
-            tree_item = QTreeWidgetItem()
+            self.queue_item_class = None
+            self.queue_item_parent = None
+            return
+
+        parent = queue_tree_widget.parent()
+        while parent:
+            if hasattr(parent, 'move_queue_item_up_inline'):
+                self.queue_item_parent = parent
+                return
+            parent = parent.parent()
+        self.queue_item_parent = None
+
+    def _create_queue_item(self, queue_tree_widget):
+        """Create queue item by type."""
+        self._get_queue_tree_parent(queue_tree_widget)
+        if self.queue_item_class and self.queue_item_parent:
+            return self.queue_item_class(['', '', ''], self.queue_item_parent)
+        return QTreeWidgetItem()
+
+    def add_formatted_item_to_queue(self, queue_data, queue_tree_widget, create_buttons=True, fetch_missing_size=True):
+        # Add formatted item to the queue list
+        tree_item = self._create_queue_item(queue_tree_widget)
         
         # Support both new format (dict) and old format (string)
         if isinstance(queue_data, dict):
@@ -124,7 +148,7 @@ class QueueManager(QObject):
             tree_item.setText(0, clean_text)
             
             # Set size in second column - try to fetch if empty
-            if not size:
+            if not size and fetch_missing_size:
                 size = self._fetch_file_size_for_item(item_text)
             tree_item.setText(1, size)
             tree_item.setTextAlignment(1, Qt.AlignRight)  # Right-align size
@@ -137,7 +161,7 @@ class QueueManager(QObject):
         queue_tree_widget.addTopLevelItem(tree_item)
         
         # Create inline buttons if this is a QueueTreeWidgetItem
-        if hasattr(tree_item, 'create_buttons'):
+        if create_buttons and hasattr(tree_item, 'create_buttons'):
             tree_item.create_buttons(queue_tree_widget)
         
         # Ensure columns are properly sized after adding item
@@ -151,6 +175,25 @@ class QueueManager(QObject):
                 pass  # Let the resize modes handle it
         
         return tree_item
+
+    def add_formatted_items_to_queue(self, queue_items, queue_tree_widget, create_buttons=False, fetch_missing_size=False):
+        """Add queue items, with UI updates paused and resumed."""
+        if not queue_items:
+            return
+
+        queue_tree_widget.setUpdatesEnabled(False)
+        queue_tree_widget.blockSignals(True)
+        try:
+            for queue_data in queue_items:
+                self.add_formatted_item_to_queue(
+                    queue_data,
+                    queue_tree_widget,
+                    create_buttons=create_buttons,
+                    fetch_missing_size=fetch_missing_size
+                )
+        finally:
+            queue_tree_widget.blockSignals(False)
+            queue_tree_widget.setUpdatesEnabled(True)
     
     def remove_from_queue(self, selected_items, queue_tree_widget):
         """Remove selected items from the download queue."""

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -11,7 +11,7 @@ from PyQt5.QtWidgets import (
     QMessageBox, QListWidget, QListWidgetItem, QFormLayout, QDialogButtonBox, QGridLayout,
     QSplitter, QFrame, QSizePolicy, QComboBox
 )
-from PyQt5.QtCore import Qt, QSettings, QThread, pyqtSignal, QEventLoop, QTimer, QUrl # Removed QPropertyAnimation, QEasingCurve
+from PyQt5.QtCore import Qt, QSettings, QThread, pyqtSignal, QEventLoop, QTimer, QUrl, QPoint # Removed QPropertyAnimation, QEasingCurve
 from PyQt5.QtGui import QFont, QBrush, QColor, QDesktopServices
 
 from gui.output_window import OutputWindow
@@ -261,12 +261,18 @@ class GUIDownloader(QWidget):
             if self.queue_list.topLevelItemCount() == 0:
                 print("No resumable download found by AppController. Loading queue from storage.")
                 queue_data = self.app_controller.queue_manager.load_queue()
+                qqueue_data = []
                 for item_data in queue_data:
                     if isinstance(item_data, dict):
-                        self.app_controller.queue_manager.add_formatted_item_to_queue(item_data, self.queue_list)
+                        qqueue_data.append(item_data)
                     else:
-                        item_dict = {'name': item_data, 'size': ''}
-                        self.app_controller.queue_manager.add_formatted_item_to_queue(item_dict, self.queue_list)
+                        qqueue_data.append({'name': item_data, 'size': ''})
+                self.app_controller.queue_manager.add_formatted_items_to_queue(
+                    qqueue_data,
+                    self.queue_list,
+                    create_buttons=False,
+                    fetch_missing_size=False
+                )
             else:
                 print("Queue already populated by AppController (no pause state, but queue loaded).")
 
@@ -285,6 +291,9 @@ class GUIDownloader(QWidget):
                 self.app_controller.queue_manager.update_queue_item_sizes_async(self.queue_list)
         except Exception as e:
             print(f"Error updating queue sizes: {e}")
+
+        self.update_queue_header_count()
+        self.ensure_visible_queue_buttons()
 
     def _connect_app_controller_signals(self):
         """Connect AppController signals to GUI updates."""
@@ -532,9 +541,9 @@ class GUIDownloader(QWidget):
         queue_layout.setContentsMargins(5, 5, 5, 5)
         
         # Queue header
-        queue_header = QLabel('Download Queue')
-        queue_header.setStyleSheet("font-weight: bold; font-size: 14px;")
-        queue_layout.addWidget(queue_header)
+        self.queue_header = QLabel('Download Queue (0)')
+        self.queue_header.setStyleSheet("font-weight: bold; font-size: 14px;")
+        queue_layout.addWidget(self.queue_header)
         
         # Queue list with columns
         self.queue_list = QTreeWidget()
@@ -560,6 +569,8 @@ class GUIDownloader(QWidget):
         # Match file list appearance settings
         self.queue_list.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.queue_list.itemSelectionChanged.connect(self.update_remove_from_queue_button)
+        self.queue_list.itemSelectionChanged.connect(self.ensure_selected_queue_buttons)
+        self.queue_list.verticalScrollBar().valueChanged.connect(self.ensure_visible_queue_buttons)
         self.queue_list.setAllColumnsShowFocus(True)
         self.queue_list.setUniformRowHeights(True)
         self.queue_list.setRootIsDecorated(False)  # No tree indicators like file list
@@ -1206,6 +1217,42 @@ class GUIDownloader(QWidget):
         """Enable or disable the remove from queue button based on selection."""
         selected = self.queue_list.selectedItems()
         self.remove_from_queue_button.setEnabled(bool(selected))
+
+    def ensure_selected_queue_buttons(self):
+        """Create buttons for selected queue items if not already exist."""
+        self._ensure_queue_buttons(self.queue_list.selectedItems())
+
+    def _ensure_queue_buttons(self, items):
+        """Create buttons for queue items if not already exist."""
+        for item in items:
+            if hasattr(item, 'create_buttons') and not getattr(item, 'buttons_created', False):
+                try:
+                    item.create_buttons(self.queue_list)
+                except RuntimeError:
+                    continue
+
+    def ensure_visible_queue_buttons(self, *_):
+        """Create buttons for visible queue rows."""
+        if not hasattr(self, 'queue_list') or not self.queue_list:
+            return
+
+        total_items = self.queue_list.topLevelItemCount()
+        if total_items == 0:
+            return
+
+        viewport = self.queue_list.viewport()
+        top_row = self.queue_list.indexAt(QPoint(1, 1)).row()
+        if top_row < 0:
+            top_row = 0
+
+        bottom_row = self.queue_list.indexAt(QPoint(1, max(1, viewport.height() - 2))).row()
+        if bottom_row < 0:
+            row_height = max(1, self.queue_list.sizeHintForRow(0))
+            approx_rows = max(1, viewport.height() // row_height)
+            bottom_row = min(total_items - 1, top_row + approx_rows + 2)
+
+        items = [self.queue_list.topLevelItem(row) for row in range(top_row, min(total_items, bottom_row + 1))]
+        self._ensure_queue_buttons(items)
     
     def add_to_queue(self):
         """Add selected items to the download queue."""
@@ -1215,17 +1262,11 @@ class GUIDownloader(QWidget):
         
         if 0 <= current_tab < len(platform_ids):
             current_platform = platform_ids[current_tab]
-            
-            # Create adapter objects for tree widget items to work with app controller
-            class TreeItemAdapter:
-                def __init__(self, tree_item):
-                    self.tree_item = tree_item
-                def text(self):
-                    return self.tree_item.text(0)  # Return first column text
-            
-            adapted_items = [TreeItemAdapter(item) for item in selected_items]
+
+            # Get item names
+            selected_names = [item.text(0) for item in selected_items]
             added_count = self.app_controller.add_to_queue(
-                adapted_items, current_platform, self.platforms, self.queue_list
+                selected_names, current_platform, self.platforms, self.queue_list
             )
             
             # Update all button states after adding items
@@ -1262,8 +1303,8 @@ class GUIDownloader(QWidget):
             # Save the queue with new order
             self.app_controller.save_queue(self.queue_list)
             
-            # Recreate buttons for all items and update their states
-            self.recreate_all_queue_buttons()
+            # Recreate only affected button widgets and update nearby states.
+            self._refresh_buttons_after_move(current_index, current_index - 1)
     
     def move_queue_item_down_inline(self, item):
         """Move the specified queue item down one position (called from inline buttons)."""
@@ -1284,8 +1325,31 @@ class GUIDownloader(QWidget):
             # Save the queue with new order
             self.app_controller.save_queue(self.queue_list)
             
-            # Recreate buttons for all items and update their states
-            self.recreate_all_queue_buttons()
+            # Recreate only affected button widgets and update nearby states.
+            self._refresh_buttons_after_move(current_index, current_index + 1)
+
+    def _refresh_buttons_after_move(self, old_index, new_index):
+        """Refresh button widgets only for rows affected by a single move."""
+        total_items = self.queue_list.topLevelItemCount()
+        affected = {
+            old_index - 1, old_index, old_index + 1,
+            new_index - 1, new_index, new_index + 1
+        }
+
+        for idx in sorted(i for i in affected if 0 <= i < total_items):
+            item = self.queue_list.topLevelItem(idx)
+            if not hasattr(item, 'create_buttons'):
+                continue
+
+            # Recreate buttons only where needed
+            try:
+                item.buttons_created = False
+                item.up_button = None
+                item.down_button = None
+                item.create_buttons(self.queue_list)
+                item.update_button_states(self.queue_list)
+            except RuntimeError:
+                continue
 
     def update_all_queue_button_states(self):
         """Update button states for all queue items."""
@@ -1654,11 +1718,21 @@ class GUIDownloader(QWidget):
     def _on_queue_updated(self):
         """Handle queue update signal from AppController."""
         try:
+            self.update_queue_header_count()
+            self.ensure_visible_queue_buttons()
             self.update_add_to_queue_button()
             self.update_remove_from_queue_button()
         except Exception as e:
             print(f"Error updating queue buttons: {e}")
-            
+
+    def update_queue_header_count(self):
+        """Update 'Download Queue (X)' header with queue count."""
+        if hasattr(self, 'queue_header') and self.queue_header and hasattr(self, 'queue_list') and self.queue_list:
+            count = self.queue_list.topLevelItemCount()
+        else:
+            count = 0
+        self.queue_header.setText(f"Download Queue ({count})")
+
     def _on_operation_complete(self):
         """Handle operation complete signal from AppController."""
         # Don't handle operation complete during shutdown


### PR DESCRIPTION
I added some additional urls and noticed some performance issues with the program when the queue gets large (e.g. >10000), on startup and while running/modifying.

I went ahead and fixed some of the UI performance issues, opting to only render the queue buttons that are visible, and to dynamically render them on-the-fly. No more rendering all queued UI all at once, ever.

Now the program loads large queues (>10000) a lot faster on startup and during use, fixing some UI queue hangups I experienced.

The `Download Queue` also now shows the number of remaining queued items.

Cheers,
Josh